### PR TITLE
Allow use with Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/contracts": "5.1.*|5.2.*|5.3.*|5.4.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*"
+        "illuminate/contracts": "5.1.*|5.2.*|5.3.*|5.4.* |5.5.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",


### PR DESCRIPTION
Laravel 5.5 isn't released yet, but lots of people (including me) are already using it. This PR allows the use of this package with Laravel 5.5

Also, please release a new version of this package (you can release a patch or a minor version) when you merge this PR, to avoid pulling `dev-master`.