### PR TITLE
removing type hint for __call() method on first arguement

### DIFF
--- a/src/AbstractManager.php
+++ b/src/AbstractManager.php
@@ -231,7 +231,7 @@ abstract class AbstractManager implements ManagerInterface
      *
      * @return mixed
      */
-    public function __call(string $method, array $parameters)
+    public function __call($method, array $parameters)
     {
         return $this->connection()->$method(...$parameters);
     }


### PR DESCRIPTION
Updating the __call() method on the AbstractManager class. Ran into an error similar to this issue:

https://stackoverflow.com/questions/21358268/mockery-call-has-a-different-signature.

Also feel confident this shouldn't be an issue, due to PHP under the hood is automatically type hinting the first argument to a string according to the docs.

http://php.net/manual/en/language.oop5.overloading.php#object.call